### PR TITLE
django 1.7+ compat: use simplejson directly

### DIFF
--- a/chartit/templatetags/chartit.py
+++ b/chartit/templatetags/chartit.py
@@ -1,7 +1,7 @@
 from itertools import izip_longest
 
 from django import template
-from django.utils import simplejson
+import simplejson
 from django.utils.safestring import mark_safe
 from django.conf import settings
 import posixpath


### PR DESCRIPTION
see title, this is required for django-1.7+

simplejson is already a requirement in setup.py so no change was needed there
